### PR TITLE
Fix ADR plugin variable mapping

### DIFF
--- a/chirpstack/src/adr/plugin.rs
+++ b/chirpstack/src/adr/plugin.rs
@@ -70,7 +70,7 @@ impl Handler for Plugin {
             input.set("requiredSnrForDr", req.required_snr_for_dr)?;
             input.set("installationMargin", req.installation_margin)?;
             input.set("minDr", req.min_dr)?;
-            input.set("maxRr", req.max_dr)?;
+            input.set("maxDr", req.max_dr)?;
 
             let mut uplink_history: Vec<rquickjs::Object> = Vec::new();
 


### PR DESCRIPTION
This took me a while... A very long while...
Comparing the default ADR plugin with a transscript to JS and use it as a custom ADR plugin it still didn't work.
A device very near the geateway got DR5 right after his join and first transmission with the integrated ADR algoriothm but not with the custom which I have gone over and over again and debugged with the test data and trasscribed data from a real device but using the object notation from the example.
So it seems this typo was the cause for my issue...